### PR TITLE
fix(dataflow): Fix dataflow CLI handling for SASL mechanisms

### DIFF
--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
@@ -56,7 +56,7 @@ object Cli {
     val saslUsername = Key("kafka.sasl.username", stringType)
     val saslSecret = Key("kafka.sasl.secret", stringType)
     val saslPasswordPath = Key("kafka.sasl.password.path", stringType)
-    val saslMechanism = Key("kafka.sasl.mechanism", enumType(KafkaSaslMechanisms.byName()))
+    val saslMechanism = Key("kafka.sasl.mechanism", enumType(KafkaSaslMechanisms.byName))
 
     fun args(): List<Key<Any>> {
         return listOf(

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Cli.kt
@@ -56,7 +56,7 @@ object Cli {
     val saslUsername = Key("kafka.sasl.username", stringType)
     val saslSecret = Key("kafka.sasl.secret", stringType)
     val saslPasswordPath = Key("kafka.sasl.password.path", stringType)
-    val saslMechanism = Key("kafka.sasl.mechanism", enumType(*KafkaSaslMechanisms.values()))
+    val saslMechanism = Key("kafka.sasl.mechanism", enumType(KafkaSaslMechanisms.byName()))
 
     fun args(): List<Key<Any>> {
         return listOf(

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Main.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/Main.kt
@@ -18,6 +18,7 @@ package io.seldon.dataflow
 
 import io.klogging.noCoLogger
 import io.seldon.dataflow.kafka.*
+import io.seldon.dataflow.kafka.security.KafkaSaslMechanisms
 import io.seldon.dataflow.mtls.CertificateConfig
 import io.seldon.dataflow.kafka.security.SaslConfig
 import kotlinx.coroutines.runBlocking
@@ -49,7 +50,7 @@ object Main {
         )
 
         val saslConfig = SaslConfig(
-            mechanism = config[Cli.saslMechanism].mechanism,
+            mechanism = config[Cli.saslMechanism],
             username = config[Cli.saslUsername],
             secret = config[Cli.saslSecret],
             passwordPath = config[Cli.saslPasswordPath],

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
@@ -82,12 +82,12 @@ private fun getSslProperties(params: KafkaStreamsParams): Properties {
             }
         }
 
-        val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
+        val (keyStoreConfig, trustStoreConfig) = Provider.keyStoresFromCertificates(params.security.certConfig)
         this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
         this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
         this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
-        this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
-        this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
+        this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = trustStoreConfig.trustStoreLocation
+        this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = trustStoreConfig.trustStorePassword
         this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] =
             params.security.certConfig.endpointIdentificationAlgorithm
     }

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
@@ -57,46 +57,60 @@ val kafkaTopicConfig = { maxMessageSizeBytes: Int ->
 }
 
 fun getKafkaAdminProperties(params: KafkaStreamsParams): KafkaAdminProperties {
-    return Properties().apply {
+    return getSecurityProperties(params).apply {
         this[StreamsConfig.BOOTSTRAP_SERVERS_CONFIG] = params.bootstrapServers
+    }
+}
+
+private fun getSecurityProperties(params: KafkaStreamsParams): Properties {
+    return Properties().apply {
         this[StreamsConfig.SECURITY_PROTOCOL_CONFIG] = params.security.securityProtocol.toString()
 
-        if (params.security.securityProtocol == SecurityProtocol.SSL) {
-            if (params.security.certConfig.clientSecret != "" &&
-                    params.security.certConfig.brokerSecret != "") {
-                K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
-            }
-            val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
+        when (params.security.securityProtocol) {
+            SecurityProtocol.SSL -> {
+                with(params.security.certConfig) {
+                    if (clientSecret != "" && brokerSecret != "") {
+                        K8sCertSecretsProvider.downloadCertsFromSecrets(this)
+                    }
+                }
 
-            this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
-            this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
-            this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
-            this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
-            this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
-            this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] =
-                params.security.certConfig.endpointIdentificationAlgorithm
-        } else if (params.security.securityProtocol == SecurityProtocol.SASL_SSL) {
-            if (params.security.certConfig.brokerSecret != "") {
-                K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
+                val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
+                this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
+                this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
+                this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
+                this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
+                this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
+                this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] =
+                    params.security.certConfig.endpointIdentificationAlgorithm
             }
-            val trustStoreConfig = Provider.trustStoreFromCertificates(params.security.certConfig)
-            this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = trustStoreConfig.trustStoreLocation
-            this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = trustStoreConfig.trustStorePassword
-            this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] =
-                params.security.certConfig.endpointIdentificationAlgorithm
+            SecurityProtocol.SASL_SSL -> {
+                if (params.security.certConfig.brokerSecret != "") {
+                    K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
+                }
 
-            val password = K8sPasswordSecretsProvider.downloadPasswordFromSecret(params.security.saslConfig)
-            this[SaslConfigs.SASL_MECHANISM] = params.security.saslConfig.mechanism.toString()
-            this[SaslConfigs.SASL_JAAS_CONFIG] = when (params.security.saslConfig.mechanism) {
-                KafkaSaslMechanisms.PLAIN ->
-                    "org.apache.kafka.common.security.plain.PlainLoginModule required" +
-                            """ username="${params.security.saslConfig.username}"""" +
-                            """ password="$password";"""
-                KafkaSaslMechanisms.SCRAM_SHA_256,
-                KafkaSaslMechanisms.SCRAM_SHA_512 ->
-                    "org.apache.kafka.common.security.scram.ScramLoginModule required" +
-                            """ username="${params.security.saslConfig.username}"""" +
-                            """ password="$password";"""
+                this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] =
+                    params.security.certConfig.endpointIdentificationAlgorithm
+
+                val trustStoreConfig = Provider.trustStoreFromCertificates(params.security.certConfig)
+                this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = trustStoreConfig.trustStoreLocation
+                this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = trustStoreConfig.trustStorePassword
+
+                val password = K8sPasswordSecretsProvider.downloadPasswordFromSecret(params.security.saslConfig)
+                this[SaslConfigs.SASL_MECHANISM] = params.security.saslConfig.mechanism.toString()
+                this[SaslConfigs.SASL_JAAS_CONFIG] = when (params.security.saslConfig.mechanism) {
+                    KafkaSaslMechanisms.PLAIN ->
+                        "org.apache.kafka.common.security.plain.PlainLoginModule required" +
+                                """ username="${params.security.saslConfig.username}"""" +
+                                """ password="$password";"""
+                    KafkaSaslMechanisms.SCRAM_SHA_256,
+                    KafkaSaslMechanisms.SCRAM_SHA_512 ->
+                        "org.apache.kafka.common.security.scram.ScramLoginModule required" +
+                                """ username="${params.security.saslConfig.username}"""" +
+                                """ password="$password";"""
+                }
+            }
+            else -> {
+                // No authentication, so nothing to configure
             }
         }
     }
@@ -105,7 +119,7 @@ fun getKafkaAdminProperties(params: KafkaStreamsParams): KafkaAdminProperties {
 fun getKafkaProperties(params: KafkaStreamsParams): KafkaProperties {
     // See https://docs.confluent.io/platform/current/streams/developer-guide/config-streams.html
 
-    return Properties().apply {
+    return getSecurityProperties(params).apply {
         // TODO - add version to app ID?  (From env var.)
         this[StreamsConfig.APPLICATION_ID_CONFIG] = "seldon-dataflow"
         this[StreamsConfig.BOOTSTRAP_SERVERS_CONFIG] = params.bootstrapServers
@@ -113,45 +127,6 @@ fun getKafkaProperties(params: KafkaStreamsParams): KafkaProperties {
         this[StreamsConfig.NUM_STREAM_THREADS_CONFIG] = 1
         this[StreamsConfig.SEND_BUFFER_CONFIG] = params.maxMessageSizeBytes
         this[StreamsConfig.RECEIVE_BUFFER_CONFIG] = params.maxMessageSizeBytes
-
-        // Security
-        this[StreamsConfig.SECURITY_PROTOCOL_CONFIG] = params.security.securityProtocol.toString()
-        if (params.security.securityProtocol == SecurityProtocol.SSL) {
-            this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = params.security.certConfig.endpointIdentificationAlgorithm
-            if (params.security.certConfig.clientSecret != "" &&
-                params.security.certConfig.brokerSecret != "") {
-                K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
-            }
-            val keyStoreConfig = Provider.keyStoresFromCertificates(params.security.certConfig)
-
-            this[SslConfigs.SSL_KEYSTORE_LOCATION_CONFIG] = keyStoreConfig.keyStoreLocation
-            this[SslConfigs.SSL_KEYSTORE_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
-            this[SslConfigs.SSL_KEY_PASSWORD_CONFIG] = keyStoreConfig.keyStorePassword
-            this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = keyStoreConfig.trustStoreLocation
-            this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = keyStoreConfig.trustStorePassword
-        } else if (params.security.securityProtocol == SecurityProtocol.SASL_SSL) {
-            this[SslConfigs.SSL_ENDPOINT_IDENTIFICATION_ALGORITHM_CONFIG] = params.security.certConfig.endpointIdentificationAlgorithm
-            if (params.security.certConfig.brokerSecret != "") {
-                K8sCertSecretsProvider.downloadCertsFromSecrets(params.security.certConfig)
-            }
-            val trustStoreConfig = Provider.trustStoreFromCertificates(params.security.certConfig)
-            this[SslConfigs.SSL_TRUSTSTORE_LOCATION_CONFIG] = trustStoreConfig.trustStoreLocation
-            this[SslConfigs.SSL_TRUSTSTORE_PASSWORD_CONFIG] = trustStoreConfig.trustStorePassword
-
-            val password = K8sPasswordSecretsProvider.downloadPasswordFromSecret(params.security.saslConfig)
-            this[SaslConfigs.SASL_MECHANISM] = params.security.saslConfig.mechanism.toString()
-            this[SaslConfigs.SASL_JAAS_CONFIG] = when (params.security.saslConfig.mechanism) {
-                KafkaSaslMechanisms.PLAIN ->
-                    "org.apache.kafka.common.security.plain.PlainLoginModule required" +
-                            """ username="${params.security.saslConfig.username}"""" +
-                            """ password="$password";"""
-                KafkaSaslMechanisms.SCRAM_SHA_256,
-                KafkaSaslMechanisms.SCRAM_SHA_512 ->
-                    "org.apache.kafka.common.security.scram.ScramLoginModule required" +
-                            """ username="${params.security.saslConfig.username}"""" +
-                            """ password="$password";"""
-            }
-        }
 
         // Testing
         this[StreamsConfig.REPLICATION_FACTOR_CONFIG] = params.replicationFactor

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/Configuration.kt
@@ -86,8 +86,8 @@ fun getKafkaAdminProperties(params: KafkaStreamsParams): KafkaAdminProperties {
                 params.security.certConfig.endpointIdentificationAlgorithm
 
             val password = K8sPasswordSecretsProvider.downloadPasswordFromSecret(params.security.saslConfig)
-            this[SaslConfigs.SASL_MECHANISM] = params.security.saslConfig.mechanism
-            this[SaslConfigs.SASL_JAAS_CONFIG] = when (KafkaSaslMechanisms.valueOf(params.security.saslConfig.mechanism)) {
+            this[SaslConfigs.SASL_MECHANISM] = params.security.saslConfig.mechanism.toString()
+            this[SaslConfigs.SASL_JAAS_CONFIG] = when (params.security.saslConfig.mechanism) {
                 KafkaSaslMechanisms.PLAIN ->
                     "org.apache.kafka.common.security.plain.PlainLoginModule required" +
                             """ username="${params.security.saslConfig.username}"""" +

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
@@ -22,4 +22,3 @@ enum class KafkaSaslMechanisms(private val mechanism: String) {
         val byName: Map<String, KafkaSaslMechanisms> = values().associateBy { it.toString() }
     }
 }
-

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
@@ -9,7 +9,7 @@ data class SaslConfig(
     val passwordPath: FilePath
 )
 
-enum class KafkaSaslMechanisms(val mechanism: String) {
+enum class KafkaSaslMechanisms(private val mechanism: String) {
     PLAIN("PLAIN"),
     SCRAM_SHA_256("SCRAM-SHA-256"),
     SCRAM_SHA_512("SCRAM-SHA-512");

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
@@ -19,7 +19,7 @@ enum class KafkaSaslMechanisms(val mechanism: String) {
     }
 
     companion object {
-        fun byName(): Map<String, KafkaSaslMechanisms> = values().associateBy { it.toString() }
+        val byName: Map<String, KafkaSaslMechanisms> = values().associateBy { it.toString() }
     }
 }
 

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
@@ -3,7 +3,7 @@ package io.seldon.dataflow.kafka.security
 typealias FilePath = String
 
 data class SaslConfig(
-    val mechanism: String,
+    val mechanism: KafkaSaslMechanisms,
     val username: String,
     val secret: String,
     val passwordPath: FilePath

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/kafka/security/Sasl.kt
@@ -17,5 +17,9 @@ enum class KafkaSaslMechanisms(val mechanism: String) {
     override fun toString(): String {
         return this.mechanism
     }
+
+    companion object {
+        fun byName(): Map<String, KafkaSaslMechanisms> = values().associateBy { it.toString() }
+    }
 }
 

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/mtls/Config.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/mtls/Config.kt
@@ -32,8 +32,6 @@ data class CertificateConfig(
 data class KeystoreConfig(
     val keyStorePassword: KeystorePassword,
     val keyStoreLocation: FilePath,
-    val trustStorePassword: KeystorePassword,
-    val trustStoreLocation: FilePath,
 )
 
 data class TruststoreConfig(

--- a/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/mtls/Provider.kt
+++ b/scheduler/data-flow/src/main/kotlin/io/seldon/dataflow/mtls/Provider.kt
@@ -41,12 +41,13 @@ object Provider {
     private const val keyType = "RSA"
     private const val keyName = "dataflow-engine-key"
 
-    fun keyStoresFromCertificates(certs: CertificateConfig): KeystoreConfig {
+    fun keyStoresFromCertificates(certs: CertificateConfig): Pair<KeystoreConfig, TruststoreConfig> {
         val (trustStoreLocation, trustStorePassword) = trustStoreFromCACert(certs)
         val (keyStoreLocation, keyStorePassword) = keyStoreFromCerts(certs)
         return KeystoreConfig(
             keyStorePassword = keyStorePassword,
             keyStoreLocation = keyStoreLocation,
+        ) to TruststoreConfig(
             trustStorePassword = trustStorePassword,
             trustStoreLocation = trustStoreLocation,
         )

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
@@ -1,0 +1,20 @@
+package io.seldon.dataflow
+
+import io.seldon.dataflow.kafka.security.KafkaSaslMechanisms
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class CliTest {
+
+    @Test
+    fun getSaslMechanism() {
+        val expectedMechanism = KafkaSaslMechanisms.SCRAM_SHA_512
+        val args = arrayOf("--kafka-sasl-mechanism", "SCRAM-SHA-512")
+        val cli = Cli.configWith(args)
+
+        val actualMechanism = cli[Cli.saslMechanism]
+
+        assertEquals(expectedMechanism, actualMechanism)
+    }
+}

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
@@ -1,17 +1,21 @@
 package io.seldon.dataflow
 
 import io.seldon.dataflow.kafka.security.KafkaSaslMechanisms
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
+import org.junit.jupiter.params.provider.MethodSource
 import strikt.api.expectCatching
 import strikt.assertions.isEqualTo
 import strikt.assertions.isSuccess
+import java.util.stream.Stream
 
 internal class CliTest {
 
-    @Test
-    fun getSaslMechanism() {
-        val expectedMechanism = KafkaSaslMechanisms.SCRAM_SHA_512
-        val args = arrayOf("--kafka-sasl-mechanism", "SCRAM-SHA-512")
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("saslMechanisms")
+    fun getSaslMechanism(input: String, expectedMechanism: KafkaSaslMechanisms) {
+        val args = arrayOf("--kafka-sasl-mechanism", input)
         val cli = Cli.configWith(args)
 
         expectCatching { cli[Cli.saslMechanism] }
@@ -19,6 +23,14 @@ internal class CliTest {
             .isEqualTo(expectedMechanism)
     }
 
-        assertEquals(expectedMechanism, actualMechanism)
+    companion object {
+        @JvmStatic
+        private fun saslMechanisms(): Stream<Arguments> {
+            return Stream.of(
+                arguments("SCRAM-SHA-512", KafkaSaslMechanisms.SCRAM_SHA_512),
+                arguments("SCRAM-SHA-256", KafkaSaslMechanisms.SCRAM_SHA_256),
+                arguments("PLAIN", KafkaSaslMechanisms.PLAIN),
+            )
+        }
     }
 }

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/CliTest.kt
@@ -2,8 +2,9 @@ package io.seldon.dataflow
 
 import io.seldon.dataflow.kafka.security.KafkaSaslMechanisms
 import org.junit.jupiter.api.Test
-
-import org.junit.jupiter.api.Assertions.*
+import strikt.api.expectCatching
+import strikt.assertions.isEqualTo
+import strikt.assertions.isSuccess
 
 internal class CliTest {
 
@@ -13,7 +14,10 @@ internal class CliTest {
         val args = arrayOf("--kafka-sasl-mechanism", "SCRAM-SHA-512")
         val cli = Cli.configWith(args)
 
-        val actualMechanism = cli[Cli.saslMechanism]
+        expectCatching { cli[Cli.saslMechanism] }
+            .isSuccess()
+            .isEqualTo(expectedMechanism)
+    }
 
         assertEquals(expectedMechanism, actualMechanism)
     }

--- a/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/kafka/PipelineStepTest.kt
+++ b/scheduler/data-flow/src/test/kotlin/io/seldon/dataflow/kafka/PipelineStepTest.kt
@@ -25,7 +25,6 @@ import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import strikt.api.Assertion
 import strikt.api.expect
-import strikt.api.expectThat
 import strikt.assertions.*
 import java.util.stream.Stream
 


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR fixes the handling of SASL mechanism values and their CLI parsing in the Core v2 dataflow engine.  The values Kafka expects for `sasl.mechanism` cannot be used directly with a Java/Kotlin enum because some of them have dashes in the name (`-`), e.g. `SCRAM-SHA-256`.  Instead, we need to do some manual handling around the enum we use to represent our supported SASL mechanisms.

This PR also refactors the logic responsible for creating Kafka config for the Streams and admin clients.  This refactoring achieves two things: it removes duplication around SASL & TLS config, and it separates the config into smaller, more understandable blocks of responsibility.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
